### PR TITLE
Automatic Dockerfile Image Updater

### DIFF
--- a/EmailProcessor/EmailProcessor.Worker/Dockerfile
+++ b/EmailProcessor/EmailProcessor.Worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:5.0-alpine AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0.2 AS runtime
 WORKDIR /app
 EXPOSE 80
 

--- a/EmailProcessor/EmailProcessor.Worker/Dockerfile-slow-connection
+++ b/EmailProcessor/EmailProcessor.Worker/Dockerfile-slow-connection
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:5.0-alpine AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0.2 AS runtime
 WORKDIR /app
 EXPOSE 80
 

--- a/Gateway/Gateway.API/Dockerfile
+++ b/Gateway/Gateway.API/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:5.0-alpine AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0.2 AS runtime
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443

--- a/Gateway/Gateway.API/Dockerfile-slow-connection
+++ b/Gateway/Gateway.API/Dockerfile-slow-connection
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:5.0-alpine AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0.2 AS runtime
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443

--- a/Logger/Logger.Worker/Dockerfile
+++ b/Logger/Logger.Worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:5.0-alpine AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0.2 AS runtime
 WORKDIR /app
 EXPOSE 80
 

--- a/Logger/Logger.Worker/Dockerfile-slow-connection
+++ b/Logger/Logger.Worker/Dockerfile-slow-connection
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:5.0-alpine AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0.2 AS runtime
 WORKDIR /app
 EXPOSE 80
 


### PR DESCRIPTION
`aspnet` changed recently. This pull request ensures you're using the latest version of the image and changes `aspnet` to the latest tag: `5.0.2`

New base image: `aspnet:5.0.2`